### PR TITLE
Fix some issues on Android

### DIFF
--- a/Tips/Tips.js
+++ b/Tips/Tips.js
@@ -63,7 +63,6 @@ const getArrowStyleByPosition = (position = 'top') => {
 
 const TooltipArrow = styled.View`
   position: absolute;
-  shadow-offset: { width: 0, height: 0 };
   shadow-radius: 1px;
   shadow-color: black;
   shadow-opacity: 0.5;
@@ -75,7 +74,6 @@ const Tooltip = styled.View`
   flex: -1;
   padding: 10px;
   border-radius: 4px;
-  shadow-offset: { width: 0, height: 0 };
   shadow-radius: 1px;
   shadow-color: black;
   shadow-opacity: 0.5;
@@ -322,7 +320,9 @@ export default class Tips extends PureComponent {
       return onRequestNext()
     }
 
-    return !!onRequestClose && onRequestClose()
+    if (onRequestClose) {
+      return onRequestClose()
+    }
   }
 
 
@@ -361,6 +361,7 @@ export default class Tips extends PureComponent {
           animationType="fade"
           visible={visible}
           transparent
+          onRequestClose={this.handleRequestClose}
         >
           <TouchableOpacity
             activeOpacity={1}

--- a/Tips/Tips.js
+++ b/Tips/Tips.js
@@ -320,9 +320,7 @@ export default class Tips extends PureComponent {
       return onRequestNext()
     }
 
-    if (onRequestClose) {
-      return onRequestClose()
-    }
+    return !!onRequestClose && onRequestClose()
   }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tips",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Helper to show tips when you launch your react-native for the first time",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
First of all, thanks for the great package! 

It worked perfectly on iOS, but on Android I was getting warnings and sometimes the waterfall tips wouldn't cascade properly.

I hunted down the warnings (onRequestClose prop missing on Modal) and shadow-offset in the styles and fixed those. I can't tell if the shadow-offset makes any difference, it looks the same on my devices without it. 

Without the onRequestClose prop added to the modal, Android sometimes doesn't cascade properly. I'm not sure why this doesn't happen on iOS, but it works on both iOS and Android with this fix.  

This references issue #12 